### PR TITLE
Render enhancements

### DIFF
--- a/src/js/bsp-template.js
+++ b/src/js/bsp-template.js
@@ -411,6 +411,9 @@ export default {
         var self = this;
 
         Handlebars.registerHelper('render', function(object, context) {
+            if (typeof object !== 'object') {
+                return object.toString();
+            }
 
             // the hash contains the extra data that we can pass onto the renderer
             // usually we just add an extra class, but this allows us to add any sort of key/value pair for use


### PR DESCRIPTION
This PR adds two features related to rendering:
1. Given `{ "foo": "bar&qux" }`, `{{render foo}}` will output `bar&amp;qux` instead of returning an empty string.
2. Given `{ "foo": { "_template": "..." } }`, `{{foo}}` will work like `{{render foo}}`.
